### PR TITLE
Checking Domain Validity

### DIFF
--- a/PublicSuffix.Test/DomainTest.cs
+++ b/PublicSuffix.Test/DomainTest.cs
@@ -1,0 +1,60 @@
+﻿//
+// DomainTest.cs
+//
+// Author:
+//       PseudoMuto <david.muto@gmail.com>
+//
+// Copyright (c) 2015 PseudoMuto
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using NUnit.Framework;
+
+namespace PublicSuffix.Test
+{
+	[TestFixture]
+	public class DomainTest
+	{
+		[TestCase]
+		public void IsDomainReturnsFalseWhenEitherTLDOrSLDIsNull()
+		{
+			Assert.IsFalse(new Domain(null).IsDomain);
+			Assert.IsFalse(new Domain("  ").IsDomain);
+			Assert.IsFalse(new Domain("com").IsDomain);
+			Assert.IsFalse(new Domain("", "google").IsDomain);
+			Assert.IsFalse(new Domain("com", "    ").IsDomain);
+		}
+
+		[TestCase]
+		public void IsDomainIsTrueWhenBothTLDAndSLDAreValid()
+		{
+			Assert.IsTrue(new Domain("com", "google").IsDomain);
+			Assert.IsTrue(new Domain("com", "google", "www").IsDomain);
+		}
+
+		[TestCase]
+		public void ToStringReturnsFQDN()
+		{
+			Assert.AreEqual("google.com", new Domain("com", "google").ToString());
+			Assert.AreEqual("www.google.com", new Domain("com", "google", "www").ToString());
+			Assert.AreEqual("a.b.c.google.com", new Domain("com", "google", "a.b.c").ToString());
+		}
+	}
+}
+

--- a/PublicSuffix.Test/DomainTest.cs
+++ b/PublicSuffix.Test/DomainTest.cs
@@ -48,12 +48,21 @@ namespace PublicSuffix.Test
 			Assert.IsTrue(new Domain("com", "google", "www").IsDomain);
 		}
 
-		[TestCase]
-		public void ToStringReturnsFQDN()
+		public void IsValidVerifiesThatThisDomainIsValidInTheDefaultList()
 		{
-			Assert.AreEqual("google.com", new Domain("com", "google").ToString());
-			Assert.AreEqual("www.google.com", new Domain("com", "google", "www").ToString());
-			Assert.AreEqual("a.b.c.google.com", new Domain("com", "google", "a.b.c").ToString());
+			Assert.IsFalse(new Domain("com").IsValid);
+			Assert.IsTrue(new Domain("com", "example").IsValid);
+			Assert.IsTrue(new Domain("com", "example", "www").IsValid);
+
+			// unknown domain
+			Assert.IsFalse(new Domain("qqq").IsValid);
+			Assert.IsFalse(new Domain("qqq", "example").IsValid);
+			Assert.IsFalse(new Domain("qqq", "example", "www").IsValid);
+
+			// restricted domain
+			Assert.IsFalse(new Domain("ke").IsValid);
+			Assert.IsFalse(new Domain("ke", "example").IsValid);
+			Assert.IsTrue(new Domain("ke", "example", "www").IsValid);
 		}
 	}
 }

--- a/PublicSuffix.Test/PublicSuffix.Test.csproj
+++ b/PublicSuffix.Test/PublicSuffix.Test.csproj
@@ -41,6 +41,7 @@
     <Compile Include="ListTest.cs" />
     <Compile Include="ListParserTest.cs" />
     <Compile Include="DomainTest.cs" />
+    <Compile Include="PublicSuffixListTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/PublicSuffix.Test/PublicSuffix.Test.csproj
+++ b/PublicSuffix.Test/PublicSuffix.Test.csproj
@@ -40,6 +40,7 @@
     <Compile Include="RuleTest.cs" />
     <Compile Include="ListTest.cs" />
     <Compile Include="ListParserTest.cs" />
+    <Compile Include="DomainTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/PublicSuffix.Test/PublicSuffixListTest.cs
+++ b/PublicSuffix.Test/PublicSuffixListTest.cs
@@ -90,5 +90,28 @@ namespace PublicSuffix.Test
 				() => PublicSuffixList.Parse("example.ke")
 			);
 		}
+
+		[TestCase]
+		public void IsValidChecksDomainValidity()
+		{
+			var validDomains = new string[] {
+				"google.com", "google.com.",
+				"www.google.com", "google.co.uk", "google.co.uk."
+			};
+
+			var invalidDomains = new string[] {
+				"google.ke", "google.qqq"
+			};
+
+			foreach (var domain in validDomains)
+			{
+				Assert.IsTrue(PublicSuffixList.IsValid(domain));
+			}
+
+			foreach (var domain in invalidDomains)
+			{
+				Assert.IsFalse(PublicSuffixList.IsValid(domain));
+			}
+		}
 	}
 }

--- a/PublicSuffix.Test/PublicSuffixListTest.cs
+++ b/PublicSuffix.Test/PublicSuffixListTest.cs
@@ -1,0 +1,94 @@
+﻿//
+// PublicSuffixTest.cs
+//
+// Author:
+//       PseudoMuto <david.muto@gmail.com>
+//
+// Copyright (c) 2015 PseudoMuto
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using NUnit.Framework;
+
+namespace PublicSuffix.Test
+{
+	[TestFixture]
+	public class PublicSuffixListTest
+	{
+		[TestCase]
+		public void ParseDomainWithoutSubDomain()
+		{
+			var domain = PublicSuffixList.Parse("example.com");
+			Assert.AreEqual("com", domain.TopLevelDomain);
+			Assert.AreEqual("example", domain.SecondLevelDomain);
+			Assert.IsTrue(string.IsNullOrEmpty(domain.SubDomain));
+
+			domain = PublicSuffixList.Parse("example.co.uk");
+			Assert.AreEqual("co.uk", domain.TopLevelDomain);
+			Assert.AreEqual("example", domain.SecondLevelDomain);
+			Assert.IsTrue(string.IsNullOrEmpty(domain.SubDomain));
+		}
+
+		[TestCase]
+		public void ParseDomainWithSingleSubDomain()
+		{
+			var domain = PublicSuffixList.Parse("alpha.example.com");
+			Assert.AreEqual("com", domain.TopLevelDomain);
+			Assert.AreEqual("example", domain.SecondLevelDomain);
+			Assert.AreEqual("alpha", domain.SubDomain);
+
+			domain = PublicSuffixList.Parse("alpha.example.co.uk");
+			Assert.AreEqual("co.uk", domain.TopLevelDomain);
+			Assert.AreEqual("example", domain.SecondLevelDomain);
+			Assert.AreEqual("alpha", domain.SubDomain);
+		}
+
+		[TestCase]
+		public void ParseDomainWithMultipleSubDomain()
+		{
+			var domain = PublicSuffixList.Parse("alpha.beta.example.com");
+			Assert.AreEqual("com", domain.TopLevelDomain);
+			Assert.AreEqual("example", domain.SecondLevelDomain);
+			Assert.AreEqual("alpha.beta", domain.SubDomain);
+
+			domain = PublicSuffixList.Parse("alpha.beta.example.co.uk");
+			Assert.AreEqual("co.uk", domain.TopLevelDomain);
+			Assert.AreEqual("example", domain.SecondLevelDomain);
+			Assert.AreEqual("alpha.beta", domain.SubDomain);
+		}
+
+		[TestCase]
+		public void ParseDomainThrowsInvalidDomainException()
+		{
+			Assert.Throws(
+				typeof(InvalidDomainException),
+				() => PublicSuffixList.Parse("example.qqq")
+			);
+		}
+
+		[TestCase]
+		public void ParseDomainThrowsBlockedDomainException()
+		{
+			Assert.Throws(
+				typeof(BlockedDomainException),
+				() => PublicSuffixList.Parse("example.ke")
+			);
+		}
+	}
+}

--- a/PublicSuffix.Test/Rules/ExceptionRuleTest.cs
+++ b/PublicSuffix.Test/Rules/ExceptionRuleTest.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 using System;
 using NUnit.Framework;
+using System.Collections.Generic;
 
 namespace PublicSuffix.Test
 {
@@ -59,7 +60,66 @@ namespace PublicSuffix.Test
 			Assert.IsTrue(Rule.Parse("!uk").IsMatch("co.uk."));
 			Assert.IsTrue(Rule.Parse("!uk").IsMatch("example.co.uk."));
 			Assert.IsTrue(Rule.Parse("!uk").IsMatch("www.example.co.uk."));
-		}			
+		}
+
+		[TestCase]
+		public void PartsSplitsDomainAppropriately()
+		{
+			var expectations = new Dictionary<string, string[]> {
+				{ "!british-library.uk", new string[] { "uk" } },
+				{ "!metro.tokyo.jp", new string[] { "tokyo", "jp" } }
+			};
+
+			foreach (var host in expectations.Keys)
+			{
+				CollectionAssert.AreEqual(expectations[host], Rule.Parse(host).Parts);
+			}
+		}
+
+		[TestCase]
+		public void LengthReturnsTheNumberOfParts()
+		{
+			Assert.AreEqual(1, Rule.Parse("!british-library.uk").Length);
+			Assert.AreEqual(2, Rule.Parse("!foo.british-library.uk").Length);
+		}
+
+		[TestCase]
+		public void IsAllowedChecksToSeeIfTheHostIsValid()
+		{
+			var rule = Rule.Parse("!british-library.uk");
+			Assert.AreEqual("ExceptionRule", rule.Type);
+
+			Assert.IsFalse(rule.IsAllowed("uk"));
+			Assert.IsTrue(rule.IsAllowed("british-library.uk"));
+			Assert.IsTrue(rule.IsAllowed("www.british-library.uk"));
+
+			Assert.IsFalse(rule.IsAllowed("uk."));
+			Assert.IsTrue(rule.IsAllowed("british-library.uk."));
+			Assert.IsTrue(rule.IsAllowed("www.british-library.uk."));
+		}
+
+		[TestCase]
+		public void DecomposeBreaksDownHosts()
+		{
+			var expectations = new Dictionary<string, string[]> {
+				{ "uk", new string[] { string.Empty, string.Empty } },
+				{ "british-library.uk", new string[] { "british-library", "uk" } },
+				{ "foo.british-library.uk", new string[] { "foo.british-library", "uk" } },
+
+				// FQDN
+				{ "uk.", new string[] { string.Empty, string.Empty } },
+				{ "british-library.uk.", new string[] { "british-library", "uk" } },
+				{ "foo.british-library.uk.", new string[] { "foo.british-library", "uk" } }
+			};
+
+			var rule = Rule.Parse("!british-library.uk");
+			Assert.AreEqual("ExceptionRule", rule.Type);
+
+			foreach (var host in expectations.Keys)
+			{
+				CollectionAssert.AreEqual(expectations[host], rule.Decompose(host));
+			}
+		}
 	}
 }
 

--- a/PublicSuffix/Domain.cs
+++ b/PublicSuffix/Domain.cs
@@ -48,11 +48,25 @@ namespace PublicSuffix
 			} 
 		}
 
+		public bool IsValid
+		{
+			get
+			{
+				var rule = GetRule();
+				return rule != null && rule.IsAllowed(ToString());
+			}
+		}
+
 		public Domain(string topLevelDomain, string secondLevelDomain = null, string subDomain = null)
 		{
 			TopLevelDomain = topLevelDomain;
 			SecondLevelDomain = secondLevelDomain;
 			SubDomain = subDomain;
+		}
+
+		public Rule GetRule()
+		{
+			return List.DefaultList.GetMatch(ToString());
 		}
 
 		public override string ToString()

--- a/PublicSuffix/Domain.cs
+++ b/PublicSuffix/Domain.cs
@@ -1,0 +1,67 @@
+﻿//
+// Domain.cs
+//
+// Author:
+//       PseudoMuto <david.muto@gmail.com>
+//
+// Copyright (c) 2015 PseudoMuto
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace PublicSuffix
+{
+	public class Domain
+	{
+		public string TopLevelDomain  { get; private set; }
+
+		public string SecondLevelDomain  { get; private set; }
+
+		public string SubDomain  { get; private set; }
+
+		public bool IsDomain
+		{ 
+			get
+			{ 				
+				return !(
+				    string.IsNullOrWhiteSpace(TopLevelDomain) ||
+				    string.IsNullOrWhiteSpace(SecondLevelDomain)
+				); 
+			} 
+		}
+
+		public Domain(string topLevelDomain, string secondLevelDomain = null, string subDomain = null)
+		{
+			TopLevelDomain = topLevelDomain;
+			SecondLevelDomain = secondLevelDomain;
+			SubDomain = subDomain;
+		}
+
+		public override string ToString()
+		{
+			var parts = new List<string> { SubDomain, SecondLevelDomain, TopLevelDomain };
+			parts.RemoveAll(string.IsNullOrWhiteSpace);
+
+			return string.Join(".", parts);
+		}
+	}
+}
+

--- a/PublicSuffix/Exceptions/BlockedDomainException.cs
+++ b/PublicSuffix/Exceptions/BlockedDomainException.cs
@@ -1,0 +1,40 @@
+﻿//
+// BlockedDomainException.cs
+//
+// Author:
+//       PseudoMuto <david.muto@gmail.com>
+//
+// Copyright (c) 2015 PseudoMuto
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+
+namespace PublicSuffix
+{
+	public class BlockedDomainException : Exception
+	{
+		private static readonly string MESSAGE_FORMAT = "'{0}' is not allowed by the Registry policy";
+
+		public BlockedDomainException(string host)
+			: base(string.Format(MESSAGE_FORMAT, host))
+		{			
+		}
+	}
+}
+

--- a/PublicSuffix/Exceptions/InvalidDomainException.cs
+++ b/PublicSuffix/Exceptions/InvalidDomainException.cs
@@ -1,0 +1,40 @@
+﻿//
+// InvalidDomainException.cs
+//
+// Author:
+//       PseudoMuto <david.muto@gmail.com>
+//
+// Copyright (c) 2015 PseudoMuto
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+
+namespace PublicSuffix
+{
+	public class InvalidDomainException : Exception
+	{
+		private static readonly string MESSAGE_FORMAT = "`{0}` is not a valid domain";
+
+		public InvalidDomainException(string host)
+			: base(string.Format(MESSAGE_FORMAT, host))
+		{
+		}
+	}
+}
+

--- a/PublicSuffix/Properties/AssemblyInfo.cs
+++ b/PublicSuffix/Properties/AssemblyInfo.cs
@@ -37,6 +37,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 
 [assembly: ComVisible(false)]
+[assembly: InternalsVisibleTo("PublicSuffix.Test")]
 
 [assembly: AssemblyVersion("0.1.0")]
 [assembly: AssemblyInformationalVersion("0.1.0")]

--- a/PublicSuffix/PublicSuffix.csproj
+++ b/PublicSuffix/PublicSuffix.csproj
@@ -39,11 +39,15 @@
     <Compile Include="List.cs" />
     <Compile Include="ListParser.cs" />
     <Compile Include="Domain.cs" />
+    <Compile Include="PublicSuffixList.cs" />
+    <Compile Include="Exceptions\InvalidDomainException.cs" />
+    <Compile Include="Exceptions\BlockedDomainException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Folder Include="Rules\" />
     <Folder Include="Data\" />
+    <Folder Include="Exceptions\" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Data\public_suffix_list.dat" />

--- a/PublicSuffix/PublicSuffix.csproj
+++ b/PublicSuffix/PublicSuffix.csproj
@@ -38,6 +38,7 @@
     <Compile Include="Rule.cs" />
     <Compile Include="List.cs" />
     <Compile Include="ListParser.cs" />
+    <Compile Include="Domain.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/PublicSuffix/PublicSuffixList.cs
+++ b/PublicSuffix/PublicSuffixList.cs
@@ -34,14 +34,7 @@ namespace PublicSuffix
 		public static Domain Parse(string host, List list = null)
 		{
 			var rule = (list ?? List.DefaultList).GetMatch(host);
-
-			if (rule == null)
-			{
-				throw new InvalidDomainException(host);
-			} else if (!rule.IsAllowed(host))
-			{
-				throw new BlockedDomainException(host);
-			}
+			EnsureValidHostForRule(host, rule);
 
 			var parts = rule.Decompose(host);
 			var hosts = new Stack<string>(parts.First().Split('.'));
@@ -51,6 +44,23 @@ namespace PublicSuffix
 			var sub = hosts.Count == 0 ? null : string.Join(".", hosts.Reverse());
 
 			return new Domain(tld, sld, sub);
+		}
+
+		public static bool IsValid(string host, List list = null)
+		{
+			var rule = (list ?? List.DefaultList).GetMatch(host);
+			return rule != null && rule.IsAllowed(host);
+		}
+
+		private static void EnsureValidHostForRule(string host, Rule rule)
+		{
+			if (rule == null)
+			{
+				throw new InvalidDomainException(host);
+			} else if (!rule.IsAllowed(host))
+			{
+				throw new BlockedDomainException(host);
+			}
 		}
 	}
 }

--- a/PublicSuffix/PublicSuffixList.cs
+++ b/PublicSuffix/PublicSuffixList.cs
@@ -1,0 +1,56 @@
+﻿//
+// PublicSuffix.cs
+//
+// Author:
+//       PseudoMuto <david.muto@gmail.com>
+//
+// Copyright (c) 2015 PseudoMuto
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace PublicSuffix
+{
+	public static class PublicSuffixList
+	{
+		public static Domain Parse(string host, List list = null)
+		{
+			var rule = (list ?? List.DefaultList).GetMatch(host);
+
+			if (rule == null)
+			{
+				throw new InvalidDomainException(host);
+			} else if (!rule.IsAllowed(host))
+			{
+				throw new BlockedDomainException(host);
+			}
+
+			var parts = rule.Decompose(host);
+			var hosts = new Stack<string>(parts.First().Split('.'));
+
+			var tld = parts.Last();
+			var sld = hosts.Count == 0 ? null : hosts.Pop();
+			var sub = hosts.Count == 0 ? null : string.Join(".", hosts.Reverse());
+
+			return new Domain(tld, sld, sub);
+		}
+	}
+}

--- a/PublicSuffix/Rules/ExceptionRule.cs
+++ b/PublicSuffix/Rules/ExceptionRule.cs
@@ -24,11 +24,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.Linq;
 
 namespace PublicSuffix
 {
 	internal class ExceptionRule : Rule
 	{
+		public override string[] Parts { get { return base.Parts.Skip(1).ToArray(); } }
+
 		public ExceptionRule(string name)
 			: base(name, name.Substring(1))
 		{

--- a/PublicSuffix/Rules/NormalRule.cs
+++ b/PublicSuffix/Rules/NormalRule.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.Text.RegularExpressions;
 
 namespace PublicSuffix
 {

--- a/PublicSuffix/Rules/NormalRule.cs
+++ b/PublicSuffix/Rules/NormalRule.cs
@@ -24,7 +24,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
-using System.Text.RegularExpressions;
 
 namespace PublicSuffix
 {

--- a/PublicSuffix/Rules/WilcardRule.cs
+++ b/PublicSuffix/Rules/WilcardRule.cs
@@ -24,14 +24,25 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.Text.RegularExpressions;
 
 namespace PublicSuffix
 {
 	internal class WilcardRule : Rule
 	{
+		public override int Length { get { return Parts.Length + 1; } }
+
 		public WilcardRule(string name)
 			: base(name, name.Substring(2))
 		{
+		}
+
+		protected internal override string[] Decompose(string host)
+		{
+			var pattern = string.Concat(@"^(.*)\.(.*?\.", string.Join(@"\.", Parts), ")$");
+			var match = new Regex(pattern, RegexOptions.IgnoreCase).Match(host.Trim('.'));
+
+			return new string[] { match.Groups[1].Value, match.Groups[2].Value };
 		}
 	}
 }


### PR DESCRIPTION
# The Problem

Breaking a domain down into it's TLD, SLD and subdomain can be a challenge. There needs to be a nice way to parse a domain by it's host. 

Validation is also tricky. Especially when you want to take into account restricted domains like `<restricted>.ke`, but still allow `sub.restricted.ke`, since it's valid.
# The Solution

Adding `PublicSuffixList` as the main entry point for this library. It exposes two static methods `Parse` and `IsValid`.

`Parse` will find the rule for the given host and if valid, will return a `Domain` object with the domain information. If there is no rule for the host or the rule doesn't allow the host, the appropriate exception is thrown.

`IsValid` will find the rule for the given host and return whether or not the rule allows that host.
